### PR TITLE
Expose providers

### DIFF
--- a/lib/ai_toolkit.rb
+++ b/lib/ai_toolkit.rb
@@ -9,6 +9,7 @@ require_relative "ai_toolkit/tool_request"
 require_relative "ai_toolkit/tool_response"
 require_relative "ai_toolkit/message_result"
 require_relative "ai_toolkit/tool"
+require_relative "ai_toolkit/providers"
 
 module AiToolkit
   class Error < StandardError; end

--- a/lib/ai_toolkit/providers.rb
+++ b/lib/ai_toolkit/providers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AiToolkit
+  # Namespace for provider implementations
+  module Providers
+  end
+end
+
+require_relative "providers/claude"
+require_relative "providers/bedrock"
+require_relative "providers/fake"


### PR DESCRIPTION
## Summary
- expose AiToolkit::Providers when requiring the gem

## Testing
- `bundle exec rake test`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_685d3d06c428833287238f8810b223a3