### PR TITLE
Update changelog with provider exposure note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1] - 2025-06-26
+### Fixed
+- Providers are now exposed via `AiToolkit::Providers`.
+
 ## [0.1.0] - 2025-06-22
 ### Added
 - Simple Ruby DSL for building Claude requests with `system_prompt`, `message`, and `tool` calls.


### PR DESCRIPTION
## Summary
- document provider exposure fix in the changelog

## Testing
- `bundle exec rake test`
- `bundle exec rubocop`


------
https://chatgpt.com/codex/tasks/task_e_685d54d516208332b3fd1fe90dc18f61