### PR TITLE
Add hooks around LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,22 @@ Run the test suite with:
 ```
 rake test
 ```
+
+## Hooks
+
+`AiToolkit::Client` allows registering callbacks before and after each provider
+call:
+
+```ruby
+client.before_request do |req, model:, provider:|
+  # inspect or modify `req`
+end
+
+client.after_request do |req, res, model:, provider:|
+  # inspect request and response
+end
+```
+
+The before hook may modify the request hash. Errors raised by the before hook
+propagate and abort the LLM request. Errors raised in the after hook are
+swallowed but will stop any automatic tool loop.

--- a/lib/ai_toolkit/providers/bedrock.rb
+++ b/lib/ai_toolkit/providers/bedrock.rb
@@ -11,6 +11,8 @@ module AiToolkit
   module Providers
     # Provider for Anthropic models via AWS Bedrock
     class Bedrock
+      attr_reader :model_id
+
       # @param model_id [String]
       # @param client [Aws::BedrockRuntime::Client, nil]
       def initialize(model_id:, client: nil)

--- a/lib/ai_toolkit/providers/claude.rb
+++ b/lib/ai_toolkit/providers/claude.rb
@@ -7,6 +7,8 @@ module AiToolkit
   module Providers
     # Provider for the Anthropic Claude API
     class Claude
+      attr_reader :model
+
       API_URL = "https://api.anthropic.com/v1/messages"
 
       # @param api_key [String]

--- a/lib/ai_toolkit/providers/fake.rb
+++ b/lib/ai_toolkit/providers/fake.rb
@@ -4,10 +4,14 @@ module AiToolkit
   module Providers
     # Simple provider used in tests that returns predefined responses
     class Fake
+      attr_reader :model
+
       # @param responses [Array<Hash>]
-      def initialize(responses)
+      # @param model [String]
+      def initialize(responses, model: "fake")
         @responses = responses
         @index = 0
+        @model = model
       end
 
       # Return the next response


### PR DESCRIPTION
## Summary
- allow registering before/after hooks in `Client`
- expose model identifiers from providers
- document the new hooks
- test hook behaviour

## Testing
- `bundle exec rake test`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_685e1acda8b08332b5e470cab4634262